### PR TITLE
Use ResizeObserver (when available)

### DIFF
--- a/text-balancer.standalone.js
+++ b/text-balancer.standalone.js
@@ -19,7 +19,14 @@ textBalancer = (function () {
             balanceText();
         }, 100);
 
-        window.addEventListener('resize', rebalanceText);
+        if (typeof(ResizeObserver) !== 'undefined') {
+            const observer = new ResizeObserver(rebalanceText);
+            for (let elm of candidates) {
+                observer.observe(elm);
+            }
+        } else {
+            window.addEventListener('resize', rebalanceText);
+        }
     }
 
     // HELPER FUNCTION -- initializes recursive binary search


### PR DESCRIPTION
Only rebalanceText when the observed text containers changes size. Fallback to resize listener for ancient browsers.

Further optimization potential: only rebalanceText on the elements that changed size.

From https://github.com/nytimes/text-balancer/pull/8